### PR TITLE
修复stopFlipping后又startFlipping动画结束的回调执行两次导致下标错位的问题

### DIFF
--- a/marqueeview/src/main/java/com/sunfusheng/marqueeview/MarqueeView.java
+++ b/marqueeview/src/main/java/com/sunfusheng/marqueeview/MarqueeView.java
@@ -52,7 +52,6 @@ public class MarqueeView<T> extends ViewFlipper {
     @AnimRes
     private int outAnimResId = R.anim.anim_top_out;
 
-    private int position;
     private List<T> messages = new ArrayList<>();
     private OnItemClickListener onItemClickListener;
 
@@ -227,8 +226,7 @@ public class MarqueeView<T> extends ViewFlipper {
         if (messages == null || messages.isEmpty()) {
             throw new RuntimeException("The messages cannot be empty!");
         }
-        position = 0;
-        addView(createTextView(messages.get(position)));
+        addView(createTextView(messages.get(0), 0));
 
         if (messages.size() > 1) {
             setInAndOutAnimation(inAnimResId, outAnimResID);
@@ -247,11 +245,14 @@ public class MarqueeView<T> extends ViewFlipper {
 
                 @Override
                 public void onAnimationEnd(Animation animation) {
-                    position++;
-                    if (position >= messages.size()) {
+                    // 获取当前View对应的下标
+                    int position = getPosition();
+                    // 对下标作越界判断
+                    if (++position >= messages.size()) {
                         position = 0;
                     }
-                    View view = createTextView(messages.get(position));
+                    // 将新的下标值保存到View中
+                    View view = createTextView(messages.get(position), position);
                     if (view.getParent() == null) {
                         addView(view);
                     }
@@ -265,7 +266,7 @@ public class MarqueeView<T> extends ViewFlipper {
         }
     }
 
-    private TextView createTextView(T marqueeItem) {
+    private TextView createTextView(T marqueeItem, int realPosition) {
         TextView textView = (TextView) getChildAt((getDisplayedChild() + 1) % 3);
         if (textView == null) {
             textView = new TextView(getContext());
@@ -297,7 +298,7 @@ public class MarqueeView<T> extends ViewFlipper {
             message = ((IMarqueeItem) marqueeItem).marqueeMessage();
         }
         textView.setText(message);
-        textView.setTag(position);
+        textView.setTag(realPosition);
         return textView;
     }
 


### PR DESCRIPTION
在动画结束的回调中position会自加1，结束的回调在stop后会执行一次，重新start后又会执行一次当前View的动画，所以会执行两次，导致position多加了1。